### PR TITLE
docs(readme): add testing requirements section

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -62,10 +62,24 @@ Testing
 
 Linux testing is done with ``kitchen-salt``.
 
+Requirements
+^^^^^^^^^^^^
+
+* Ruby
+* Docker
+
+.. code-block:: bash
+   $ gem install bundler
+   $ bundle install
+   $ bin/kitchen test [platform]
+Where ``[platform]`` is the platform name defined in ``kitchen.yml``,
+e.g. ``debian-9-2019-2-py3``.
+
+
 ``kitchen converge``
 ^^^^^^^^^^^^^^^^^^^^
 
-Creates the docker instance and runs the ``template`` main state, ready for testing.
+Creates the docker instance and runs the ``rkhunter`` main state, ready for testing.
 
 ``kitchen verify``
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This is to be merged after #10.  The main purpose of submitting it right now is to ensure the lack of Cirrus CI concurrency at a repo-level.  The checks here should run at the same time as the checks currently running on #10 (there is expected slow-down due to user-level concurrency).