### PR TITLE
feat(yamllint): include for this repo and apply rules throughout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,22 +2,27 @@
 # vim: ft=yaml
 ---
 stages:
-  - commitlint
+  - lint
   - name: release
     if: branch = master AND type != pull_request
 
 jobs:
   include:
-    # Define the commitlint stage
-    - stage: commitlint
+    # Define the `lint` stage (runs `yamllint` and `commitlint`)
+    - stage: lint
       language: node_js
       node_js: lts/*
       before_install: skip
       script:
+        # Install and run `yamllint`
+        - pip install --user yamllint
+        # yamllint disable-line rule:line-length
+        - yamllint -s . .yamllint pillar.example test/salt/pillar/debian.sls test/salt/pillar/redhat.sls test/salt/pillar/suse.sls
+        # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D
         - commitlint-travis
-    # Define the release stage that runs semantic-release
+    # Define the release stage that runs `semantic-release`
     - stage: release
       language: node_js
       node_js: lts/*

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# Extend the `default` configuration provided by `yamllint`
+extends: default
+
+# Files to ignore completely
+# 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+ignore: |
+  node_modules/
+
+rules:
+  line-length:
+    # Increase from default of `80`
+    # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
+    max: 88

--- a/pillar.example
+++ b/pillar.example
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 rkhunter:
   default:
     cron_daily_run: true

--- a/rkhunter/osfamilymap.yaml
+++ b/rkhunter/osfamilymap.yaml
@@ -132,7 +132,12 @@ Suse:
     cron_db_update: 'no'
     logfile: /var/log/rkhunter.log
     nice: 0
-    options: '"--no-mail-on-warning --cronjob --report-warnings-only --append-log --pkgmgr RPM"'
+    options: >-
+      "--no-mail-on-warning
+      --cronjob
+      --report-warnings-only
+      --append-log
+      --pkgmgr RPM"
     pro_update: 'no'
     report_email: root
     run_suseconfig: 'yes'

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: default
 title: rkhunter formula
 maintainer: SaltStack Formulas

--- a/test/salt/pillar/debian.sls
+++ b/test/salt/pillar/debian.sls
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 rkhunter:
   default:
     run_check_on_battery: true

--- a/test/salt/pillar/redhat.sls
+++ b/test/salt/pillar/redhat.sls
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 rkhunter:
   default:
     mailto: foo@localhost

--- a/test/salt/pillar/suse.sls
+++ b/test/salt/pillar/suse.sls
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 rkhunter:
   default:
     cron_db_update: 'yes'


### PR DESCRIPTION
* Semi-automated using `ssf-formula` (v0.5.0)
* Fix errors shown below:

```bash
rkhunter-formula$ $(grep "\- yamllint" .travis.yml | sed -e "s:^\s\+-\s\(.*\):\1:")
./rkhunter/osfamilymap.yaml
  135:89    error    line too long (96 > 88 characters)  (line-length)

pillar.example
  1:1       warning  missing document start "---"  (document-start)

test/salt/pillar/debian.sls
  1:1       warning  missing document start "---"  (document-start)

test/salt/pillar/redhat.sls
  1:1       warning  missing document start "---"  (document-start)

test/salt/pillar/suse.sls
  1:1       warning  missing document start "---"  (document-start)
```

---

Refer back to: https://github.com/saltstack-formulas/template-formula/pull/159#issue-305203039.